### PR TITLE
Keystone v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Installation
    $ git clone https://github.com/yosshy/oscurl.git
    ```
 
-2. Make it executable.
+2. Install python module dependencies into your system (or virtualenv).
    ```
-   $ chmod +x oscurl/oscurl
+   $ sudo pip install -r oscurl/requirements.txt
    ```
 
 3. Copy oscurl file under the execution path.
@@ -39,26 +39,33 @@ Installation
 
 4. Test oscurl.
    ```
-   $ oscurl -h
-   Usage: oscurl [options] [<request_body_file>]
+   usage: oscurl [-h] [-s SERVICE] [-m {GET,HEAD,POST,PUT,DELETE}] [-p PATH]
+                 [-P FULL_PATH] [-f {RAW,HEADER,BODY,YAML,JSON,NONE}] [-d] [-r]
+                 [-t {public,internal,admin}] [-z]
+                 [request_body_file [request_body_file ...]]
 
-   Options:
+   positional arguments:
+     request_body_file     JSON file which contains a request body
+
+   optional arguments:
      -h, --help            show this help message and exit
-     -s SERVICE, --service=SERVICE
-                           service name (cinder/ec2/glance/keystone/nova/quantum)
-                           or type (volume/ec2/image/identity/compute/network),
+     -s SERVICE, --service SERVICE
+                           service type
+                           (volume/image/identity/compute/network/...),
                            default=compute
-     -m METHOD, --method=METHOD
+     -m {GET,HEAD,POST,PUT,DELETE}, --method {GET,HEAD,POST,PUT,DELETE}
                            request method (GET/HEAD/POST/PUT/DELETE), default=GET
-     -p PATH, --path=PATH  differential path of URL
-     -P FULLPATH, --full-path=FULLPATH
+     -p PATH, --path PATH  differential path of URL
+     -P FULL_PATH, --full-path FULL_PATH
                            full path of URL
-     -f FORMAT, --format=FORMAT
+     -f {RAW,HEADER,BODY,YAML,JSON,NONE}, --format {RAW,HEADER,BODY,YAML,JSON,NONE}
                            format of response output
                            (RAW/HEADER/BODY/YAML/JSON/NONE), default=RAW
      -d, --debug           debug mode
      -r, --dump-request    dump HTTP request
-     -t API, --api=API     API type (public/internal/admin), default=public
+     -t {public,internal,admin}, --api {public,internal,admin}
+                           API type (public/internal/admin), default=public
+     -z, --delay           test mode, use expired token
    ```
 
 

--- a/oscurl
+++ b/oscurl
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
+import argparse
 import fileinput
 import json
 import httplib
-import optparse
 import os
 import logging
 import sys
@@ -99,16 +99,16 @@ def get_token(service):
     return (public_url, internal_url, admin_url, token)
 
 
-def do_request(body, **kwargs):
-    service = kwargs['service']
+def do_request(body, options):
+    service = options.service
     (purl, iurl, aurl, token) = get_token(service)
 
-    if kwargs.get('delay'):
-    	time.sleep(65)
+    if options.delay:
+        time.sleep(65)
 
-    if kwargs.get('api') == 'admin':
+    if options.api == 'admin':
         url = aurl
-    elif kwargs.get('api') == 'internal':
+    elif options.api == 'internal':
         url = iurl
     else:
         url = purl
@@ -124,8 +124,8 @@ def do_request(body, **kwargs):
     else:
         error_exit('Invalid scheme in %s\n' % url)
 
-    method = kwargs['method']
-    path = base_path + kwargs['path']
+    method = options.method
+    path = base_path + options.path
 
     request_headers = {
         'Content-Type': 'application/json',
@@ -133,12 +133,12 @@ def do_request(body, **kwargs):
         'X-Auth-Token': token,
     }
 
-    if kwargs.get('fullpath'):
-        path = kwargs['fullpath']
+    if options.full_path:
+        path = options.full_path
 
-    if kwargs.get('debug'):
+    if options.debug:
         conn.set_debuglevel(1)
-    elif kwargs.get('dump_request'):
+    elif options.dump_request:
         patch_send()
 
     conn.request(method, path, body, request_headers)
@@ -147,7 +147,7 @@ def do_request(body, **kwargs):
         error_exit('HTTP access failed: status=%d %s\n' % (
                    response.status, response.reason))
 
-    format = kwargs['format']
+    format = options.format
     response_top = format_response_top(response)
     response_headers = response.msg
     response_body_str = response.read()
@@ -178,65 +178,60 @@ def do_request(body, **kwargs):
 if __name__ == '__main__':
 
     default_service = os.environ.get('OSCURL_SERVICE', 'compute')
+    supported_methods = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE']
     default_method = os.environ.get('OSCURL_METHOD', 'GET')
+    supported_formats = ['RAW', 'HEADER', 'BODY', 'YAML', 'JSON', 'NONE']
     default_format = os.environ.get('OSCURL_FORMAT', 'RAW')
 
-    usage = "usage: %prog [options] [<request_body_file>]"
-    parser = optparse.OptionParser(usage=usage)
-    parser.add_option("-s", "--service", dest="service",
-                      help="service name "
-                      "(cinder/ec2/glance/keystone/nova/quantum)"
-                      " or type "
-                      "(volume/ec2/image/identity/compute/network)"
-                      ", " +
-                           "default=%s" % default_service,
-                      metavar="SERVICE",
-                      default=default_service)
-    parser.add_option("-m", "--method", dest="method",
-                      help="request method "
-                           "(GET/HEAD/POST/PUT/DELETE), "
-                           "default=%s" % default_method,
-                      metavar="METHOD", default=default_method)
-    parser.add_option("-p", "--path", dest="path",
-                      help="differential path of URL", metavar="PATH",
-                      default='')
-    parser.add_option("-P", "--full-path", dest="fullpath",
-                      help="full path of URL", metavar="FULLPATH")
-    parser.add_option("-f", "--format", dest="format",
-                      help="format of response output "
-                           "(RAW/HEADER/BODY/YAML/JSON/NONE), "
-                           "default=%s" % default_format,
-                      metavar="FORMAT", default=default_format)
-    parser.add_option("-d", "--debug",
-                      action="store_true", dest="debug",
-                      default=False,
-                      help="debug mode")
-    parser.add_option("-r", "--dump-request",
-                      action="store_true", dest="dump_request",
-                      default=False,
-                      help="dump HTTP request")
-    parser.add_option("-t", "--api",
-                      dest="api",
-                      default='public',
-                      help="API type (public/internal/admin), "
-                           "default=public")
-    parser.add_option("-z", "--delay",
-                      action="store_true", dest="delay",
-                      default=False,
-                      help="test mode, use expired token")
+    parser = argparse.ArgumentParser()
+    parser.add_argument('request_body_file',
+                        nargs='*',
+                        help='JSON file which contains a request body')
+    parser.add_argument("-s", "--service",
+                        help=("service name "
+                              "(cinder/ec2/glance/keystone/nova/quantum)"
+                              " or type "
+                              "(volume/ec2/image/identity/compute/network)"
+                              ", default=%s" % default_service),
+                        default=default_service)
+    parser.add_argument("-m", "--method",
+                        help=("request method "
+                              "(GET/HEAD/POST/PUT/DELETE), "
+                              "default=%s" % default_method),
+                        choices=supported_methods,
+                        default=default_method)
+    parser.add_argument("-p", "--path", dest="path",
+                        help="differential path of URL",
+                        default='')
+    parser.add_argument("-P", "--full-path",
+                        help="full path of URL")
+    parser.add_argument("-f", "--format", dest="format",
+                        help=("format of response output "
+                              "(RAW/HEADER/BODY/YAML/JSON/NONE), "
+                              "default=%s" % default_format),
+                        choices=supported_formats,
+                        default=default_format)
+    parser.add_argument("-d", "--debug",
+                        action="store_true",
+                        help="debug mode")
+    parser.add_argument("-r", "--dump-request",
+                        action="store_true",
+                        help="dump HTTP request")
+    parser.add_argument("-t", "--api",
+                        default='public',
+                        choices=['public', 'internal', 'admin'],
+                        help=("API type (public/internal/admin), "
+                              "default=public"))
+    parser.add_argument("-z", "--delay",
+                        action="store_true",
+                        help="test mode, use expired token")
 
-    (options, args) = parser.parse_args()
-
-    if options.method not in ['GET', 'HEAD', 'POST', 'PUT', 'DELETE']:
-        error_exit('invalid HTTP method %s\n' % options.method)
-
-    if options.format not in ['RAW', 'HEADER', 'BODY', 'YAML', 'JSON', 'NONE']:
-        error_exit('invalid output format %s\n' % options.format)
+    options = parser.parse_args()
 
     body = ''
-    if args:
-        for line in fileinput.input(args):
+    if options.request_body_file:
+        for line in fileinput.input(options.request_body_file):
             body += line.strip()
         json.loads(body)
 
-    do_request(body, **(options.__dict__))
+    do_request(body, options)

--- a/oscurl
+++ b/oscurl
@@ -2,13 +2,15 @@
 
 import argparse
 import fileinput
-import json
 import httplib
-import os
+import json
 import logging
+import os
 import sys
 import time
 import urlparse
+
+import os_client_config
 import yaml
 
 
@@ -45,73 +47,34 @@ def format_response_top(obj):
     return '%s %d %s' % (version_str, status, reason)
 
 
-def get_token(service):
-    for ev in ['OS_AUTH_URL', 'OS_TENANT_NAME', 'OS_USERNAME', 'OS_PASSWORD']:
-        if ev not in os.environ:
-            error_exit('%s not set\n' % ev)
+def get_token(cloud_config, options):
+    cloud = cloud_config.get_one_cloud(argparse=options)
+    try:
+        identity_client = cloud.get_session_client('identity')
+        token = identity_client.get_token()
+    except os_client_config.exceptions.OpenStackConfigException as e:
+        print 'Error occurs during authentication.'
+        print 'For most cases it is due to missing OS_* environment variables.'
+        print 'Check OS_ environment variables for authentication are set.'
+        print ('(like OS_AUTH_URL/OS_TENANT_NAME/OS_USERNAME/OS_PASSWORD '
+               'or OS_CLOUD)')
+        sys.exit(1)
 
-    urlobj = urlparse.urlparse(os.environ['OS_AUTH_URL'])
-    host = urlobj.hostname
-    port = urlobj.port
-    base_path = urlobj.path.rstrip('/')
-    if urlobj.scheme == 'http':
-        conn = httplib.HTTPConnection(host, port)
-    elif urlobj.scheme == 'https':
-        conn = httplib.HTTPSConnection(host, port)
-    else:
-        error_exit('Invalid schema in OS_AUTH_URL\n')
+    endpoint_url = cloud.get_session_endpoint(options.service)
+    if not endpoint_url:
+        print "No endpoint is found for service '%s'" % options.service
+        print ("(Note that service name like 'nova' or 'cinder' is "
+               "no longer supported.)")
+        sys.exit(1)
 
-    request_body = {
-        "auth": {
-            "tenantName": os.environ['OS_TENANT_NAME'],
-            "passwordCredentials": {
-                "username": os.environ['OS_USERNAME'],
-                "password": os.environ['OS_PASSWORD']
-            }
-        }
-    }
-    request_headers = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json'
-    }
-
-    conn.request('POST', base_path + '/tokens',
-                 json.dumps(request_body), request_headers)
-
-    response = conn.getresponse()
-    if not 200 <= response.status < 300:
-        error_exit('HTTP access failed: status=%d %s\n' % (
-                   response.status, response.reason))
-
-    response_body = json.loads(response.read())
-
-    for s in response_body['access']['serviceCatalog']:
-        if s['name'] == service or s['type'] == service:
-            break
-    else:
-        error_exit('Service %s not found\n' % service)
-
-    public_url = s['endpoints'][0]['publicURL']
-    internal_url = s['endpoints'][0]['internalURL']
-    admin_url = s['endpoints'][0]['adminURL']
-    token = response_body['access']['token']['id']
-
-    return (public_url, internal_url, admin_url, token)
+    return (endpoint_url, token)
 
 
-def do_request(body, options):
-    service = options.service
-    (purl, iurl, aurl, token) = get_token(service)
+def do_request(body, cloud_config, options):
+    (url, token) = get_token(cloud_config, options)
 
     if options.delay:
         time.sleep(65)
-
-    if options.api == 'admin':
-        url = aurl
-    elif options.api == 'internal':
-        url = iurl
-    else:
-        url = purl
 
     urlobj = urlparse.urlparse(url)
     host = urlobj.hostname
@@ -188,10 +151,8 @@ if __name__ == '__main__':
                         nargs='*',
                         help='JSON file which contains a request body')
     parser.add_argument("-s", "--service",
-                        help=("service name "
-                              "(cinder/ec2/glance/keystone/nova/quantum)"
-                              " or type "
-                              "(volume/ec2/image/identity/compute/network)"
+                        help=("service type "
+                              "(volume/image/identity/compute/network/...)"
                               ", default=%s" % default_service),
                         default=default_service)
     parser.add_argument("-m", "--method",
@@ -218,7 +179,6 @@ if __name__ == '__main__':
                         action="store_true",
                         help="dump HTTP request")
     parser.add_argument("-t", "--api",
-                        default='public',
                         choices=['public', 'internal', 'admin'],
                         help=("API type (public/internal/admin), "
                               "default=public"))
@@ -226,7 +186,20 @@ if __name__ == '__main__':
                         action="store_true",
                         help="test mode, use expired token")
 
+    # Use parse_known_args to show only oscurl options.
+    # os_client_config provides a lot of options and
+    # it might be annoying for existing oscurl users.
+    # Note that all os_client_config options like --os-cloud can be used.
+    parser.parse_known_args()
+
+    cloud_config = os_client_config.OpenStackConfig()
+    cloud_config.register_argparse_arguments(parser, sys.argv)
     options = parser.parse_args()
+
+    # os_client_config uses --os-interface option.
+    # Map --api option to --os-interface.
+    if options.api:
+        options.os_interface = options.api
 
     body = ''
     if options.request_body_file:
@@ -234,4 +207,4 @@ if __name__ == '__main__':
             body += line.strip()
         json.loads(body)
 
-    do_request(body, options)
+    do_request(body, cloud_config, options)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+os_client_config
+PyYAML


### PR DESCRIPTION
This patch series adds keystone v3 support.
The current oscurl only supports keystone v2.
OpenStack is moving to the keystone v3 era, so it is time to support it.