### PR TITLE
Set minimum version of os-client-config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-os_client_config
+os_client_config>=1.13.0
 PyYAML


### PR DESCRIPTION
oscurl assumes OpenStackConfig.register_argparse_arguments.
This method is provided since os-client-config 1.13.0.