### PR TITLE
Add slash automatically when constructing URL

### DIFF
--- a/oscurl/oscurl.py
+++ b/oscurl/oscurl.py
@@ -71,11 +71,12 @@ def do_request(body, cloud_config, options):
 
     method = options.method.upper()
     endpoint = client.get_endpoint()
-    url = endpoint + options.path
 
     if options.full_path:
         o = urlparse.urlparse(endpoint)
-        url = "%s://%s%s" % (o.scheme, o.netloc, options.full_path)
+        url = urlparse.urlunsplit((o.scheme, o.netloc, options.full_path, '', ''))
+    else:
+        url = urlparse.urljoin(endpoint, options.path)
 
     if options.debug:
         logging.basicConfig()


### PR DESCRIPTION
Previously endpoint URL and a path specified by a user is simply
concatenated and as a result users need to check a slash is required
or not carefully. This commit changes oscurl to add a slash
automatically if necessary. urlparse.urljoin and urlunsplit do that.