### PR TITLE
Prepare test env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,56 +1,15 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[cod]
-
-# C extensions
-*.so
+*.pyc
 
 # Distribution / packaging
-.Python
-env/
-bin/
 build/
-develop-eggs/
 dist/
-eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
 *.egg-info/
-.installed.cfg
-*.egg
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
+/.eggs/
 
 # Unit test / coverage reports
-htmlcov/
 .tox/
-.coverage
-.cache
-nosetests.xml
-coverage.xml
-
-# Translations
-*.mo
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-
-# Rope
-.ropeproject
-
-# Django stuff:
-*.log
-*.pot
-
-# Sphinx documentation
-docs/_build/
 
 # pbr auto-generated files
 AUTHORS

--- a/oscurl/oscurl.py
+++ b/oscurl/oscurl.py
@@ -77,7 +77,8 @@ def do_request(body, cloud_config, options):
 
     if options.full_path:
         o = urlparse.urlparse(endpoint)
-        url = urlparse.urlunsplit((o.scheme, o.netloc, options.full_path, '', ''))
+        url = urlparse.urlunsplit((o.scheme, o.netloc,
+                                   options.full_path, '', ''))
     else:
         url = urlparse.urljoin(endpoint, options.path)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+hacking

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = pep8
+minversion = 2.3.1
+skipsdist = True
+
+[testenv]
+setenv = VIRTUAL_ENV={envdir}
+         PYTHONWARNINGS=default::DeprecationWarning
+passenv = TRACE_FAILONLY GENERATE_HASHES http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
+usedevelop = True
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+
+[testenv:pep8]
+commands = flake8
+
+[flake8]
+ignore = H102
+exclude = ./.*,build,dist


### PR DESCRIPTION
This patch series sets up testenv using tox and clean up pep8 errors.
It also clean up unnecessary .gitignore entries.

Note that H233 Python 3.x incompatible use of print operator are
clean up in the other pull request for python3 support.